### PR TITLE
V7.0.2

### DIFF
--- a/src/Doctrine/Geometry.php
+++ b/src/Doctrine/Geometry.php
@@ -9,7 +9,7 @@ class Geometry extends Type
 {
     const GEOMETRY = 'geometry';
 
-    public function getSQLDeclaration(array $fieldDeclaration, AbstractPlatform $platform)
+    public function getSQLDeclaration(array $fieldDeclaration, AbstractPlatform $platform): string
     {
         return 'geometry';
     }

--- a/src/Doctrine/GeometryCollection.php
+++ b/src/Doctrine/GeometryCollection.php
@@ -9,7 +9,7 @@ class GeometryCollection extends Type
 {
     const GEOMETRYCOLLECTION = 'geometrycollection';
 
-    public function getSQLDeclaration(array $fieldDeclaration, AbstractPlatform $platform)
+    public function getSQLDeclaration(array $fieldDeclaration, AbstractPlatform $platform): string
     {
         return 'geometrycollection';
     }

--- a/src/Doctrine/LineString.php
+++ b/src/Doctrine/LineString.php
@@ -9,7 +9,7 @@ class LineString extends Type
 {
     const LINESTRING = 'linestring';
 
-    public function getSQLDeclaration(array $fieldDeclaration, AbstractPlatform $platform)
+    public function getSQLDeclaration(array $fieldDeclaration, AbstractPlatform $platform): string
     {
         return 'linestring';
     }

--- a/src/Doctrine/MultiLineString.php
+++ b/src/Doctrine/MultiLineString.php
@@ -9,7 +9,7 @@ class MultiLineString extends Type
 {
     const MULTILINESTRING = 'multilinestring';
 
-    public function getSQLDeclaration(array $fieldDeclaration, AbstractPlatform $platform)
+    public function getSQLDeclaration(array $fieldDeclaration, AbstractPlatform $platform): string
     {
         return 'multilinestring';
     }

--- a/src/Doctrine/MultiPoint.php
+++ b/src/Doctrine/MultiPoint.php
@@ -9,7 +9,7 @@ class MultiPoint extends Type
 {
     const MULTIPOINT = 'multipoint';
 
-    public function getSQLDeclaration(array $fieldDeclaration, AbstractPlatform $platform)
+    public function getSQLDeclaration(array $fieldDeclaration, AbstractPlatform $platform): string
     {
         return 'multipoint';
     }

--- a/src/Doctrine/MultiPolygon.php
+++ b/src/Doctrine/MultiPolygon.php
@@ -9,7 +9,7 @@ class MultiPolygon extends Type
 {
     const MULTIPOLYGON = 'multipolygon';
 
-    public function getSQLDeclaration(array $fieldDeclaration, AbstractPlatform $platform)
+    public function getSQLDeclaration(array $fieldDeclaration, AbstractPlatform $platform): string
     {
         return 'multipolygon';
     }

--- a/src/Doctrine/Point.php
+++ b/src/Doctrine/Point.php
@@ -9,7 +9,7 @@ class Point extends Type
 {
     const POINT = 'point';
 
-    public function getSQLDeclaration(array $fieldDeclaration, AbstractPlatform $platform)
+    public function getSQLDeclaration(array $fieldDeclaration, AbstractPlatform $platform): string
     {
         return 'point';
     }

--- a/src/Doctrine/Polygon.php
+++ b/src/Doctrine/Polygon.php
@@ -9,7 +9,7 @@ class Polygon extends Type
 {
     const POLYGON = 'polygon';
 
-    public function getSQLDeclaration(array $fieldDeclaration, AbstractPlatform $platform)
+    public function getSQLDeclaration(array $fieldDeclaration, AbstractPlatform $platform): string
     {
         return 'polygon';
     }

--- a/src/SpatialServiceProvider.php
+++ b/src/SpatialServiceProvider.php
@@ -42,10 +42,6 @@ class SpatialServiceProvider extends DatabaseServiceProvider
             return new DatabaseManager($app, $app['db.factory']);
         });
 
-        $this->app->singleton('db.schema', function ($app) {
-            return $app['db']->connection()->getSchemaBuilder();
-        });
-
         if (class_exists(DoctrineType::class)) {
             // Prevent geometry type fields from throwing a 'type not found' error when changing them
             $geometries = [


### PR DESCRIPTION
- Fixed issue with no return type on `getSQLDeclaration()` method
- Removed setting `db.schema` as causes issues with parallel testing and no longer needed